### PR TITLE
Add missing gdbm to python image

### DIFF
--- a/release-notes-70.60.2.md
+++ b/release-notes-70.60.2.md
@@ -6,7 +6,7 @@ ${version-number}
 
 #### Patch Fixes Included
  - Added missing gdbm module
-    This module is required for Celery state merging.
+    It's included to most standard Python distributions and some software are relying on it.
 
 #### Known Issues
  - None

--- a/release-notes-70.60.2.md
+++ b/release-notes-70.60.2.md
@@ -5,8 +5,8 @@ ${version-number}
  - None
 
 #### Patch Fixes Included
- - Added missing gdbm module
-    It's included to most standard Python distributions and some software are relying on it.
+ - Added missing gdbm module  
+    This module is included in most standard Python distributions.
 
 #### Known Issues
  - None

--- a/release-notes-70.60.2.md
+++ b/release-notes-70.60.2.md
@@ -1,8 +1,12 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
+ - None
+
+#### Patch Fixes Included
+ - Added missing gdbm module
+    This module is required for Celery state merging.
 
 #### Known Issues
+ - None

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -36,6 +36,7 @@ ARG DEVEL_DEPS="\
     netcfg \
     timezone \
     xz \
+    gdbm-devel \
     "
 
 RUN zypper -n refresh && \
@@ -132,6 +133,8 @@ RUN python get-pip.py \
 
 
 FROM cafapi/opensuse-base:1
+RUN zypper -n refresh && \
+    zypper -n in libgdbm4
 
 COPY --from=builder /usr/local /usr/local
 RUN ldconfig


### PR DESCRIPTION
* Required for celery state merging
* https://github.com/celery/celery/issues/5444